### PR TITLE
No cookie values in PHPUnit tests

### DIFF
--- a/src/Authentication/AuthenticationTokens.php
+++ b/src/Authentication/AuthenticationTokens.php
@@ -59,7 +59,7 @@ final class AuthenticationTokens
     }
 
     /**
-     * @return array<string, string>
+     * @return array{'X-XSRF-TOKEN': string, 'Cookie': string}
      * @throws AuthenticationException
      */
     public function getAuthenticationHeaders(): array

--- a/src/Authentication/AuthenticatorInterface.php
+++ b/src/Authentication/AuthenticatorInterface.php
@@ -25,7 +25,7 @@ interface AuthenticatorInterface
     public function authenticate(array $credentials, bool $forceAuthenticationRenewal = false): void;
 
     /**
-     * @return array<string, string>
+     * @return array{'X-XSRF-TOKEN': string, 'Cookie': string}
      * @throws AuthenticationException
      */
     public function getAuthenticationHeaders(): array;

--- a/src/Authentication/BaseAuthenticator.php
+++ b/src/Authentication/BaseAuthenticator.php
@@ -27,7 +27,7 @@ abstract class BaseAuthenticator implements AuthenticatorInterface
     }
 
     /**
-     * @return array<string, string>
+     * @return array{'X-XSRF-TOKEN': string, 'Cookie': string}
      * @throws AuthenticationException
      */
     public function getAuthenticationHeaders(): array

--- a/tests/Authentication/CookieValuesAuthenticatorTest.php
+++ b/tests/Authentication/CookieValuesAuthenticatorTest.php
@@ -8,60 +8,69 @@ use Generator;
 use ITB\CmlifeClient\Authentication\AuthenticatorException\MissingCredentialException;
 use ITB\CmlifeClient\Authentication\CookieValuesAuthenticator;
 use ITB\CmlifeClient\Authentication\CookieValuesAuthenticatorException\ForcedAuthenticationRenewalNotAllowedException;
+use ITB\CmlifeClient\Authentication\UsernamePasswordAuthenticator;
 use ITB\CmlifeClient\Exception\AuthenticationException;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\HttpClient;
 
 final class CookieValuesAuthenticatorTest extends TestCase
 {
+    use UsernameAndPasswordToCookieValuesTrait;
+
     /**
      * @return Generator
+     * @throws AuthenticationException
      */
     public function provideForTestAuthenticateWithMissingCredential(): Generator
     {
         $httpClient = HttpClient::create();
         $authenticator = new CookieValuesAuthenticator($httpClient);
+        $credentials = $this->createCookieValuesFromUsernameAndPassword($_ENV['CMLIFE_USERNAME'], $_ENV['CMLIFE_PASSWORD']);
 
         yield 'session id missing' => [
             $authenticator,
-            [CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $_ENV['CMLIFE_XSRF_TOKEN']],
+            [CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $credentials['xsrfToken']],
             CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID
         ];
         yield 'xsrf token missing' => [
             $authenticator,
-            [CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $_ENV['CMLIFE_SESSION_ID']],
+            [CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $credentials['sessionId']],
             CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN
         ];
     }
 
     /**
      * @return Generator
+     * @throws AuthenticationException
      */
     public function provideForTestAuthenticateWithValidCredentials(): Generator
     {
         $httpClient = HttpClient::create();
+        $credentials = $this->createCookieValuesFromUsernameAndPassword($_ENV['CMLIFE_USERNAME'], $_ENV['CMLIFE_PASSWORD']);
 
         yield [
             new CookieValuesAuthenticator($httpClient),
             [
-                CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $_ENV['CMLIFE_SESSION_ID'],
-                CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $_ENV['CMLIFE_XSRF_TOKEN']
+                CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $credentials['sessionId'],
+                CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $credentials['xsrfToken']
             ]
         ];
     }
 
     /**
      * @return Generator
+     * @throws AuthenticationException
      */
     public function provideForTestAuthenticationRepeated(): Generator
     {
         $httpClient = HttpClient::create();
+        $credentials = $this->createCookieValuesFromUsernameAndPassword($_ENV['CMLIFE_USERNAME'], $_ENV['CMLIFE_PASSWORD']);
 
         yield [
             new CookieValuesAuthenticator($httpClient),
             [
-                CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $_ENV['CMLIFE_SESSION_ID'],
-                CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $_ENV['CMLIFE_XSRF_TOKEN']
+                CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $credentials['sessionId'],
+                CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $credentials['sessionId']
             ]
         ];
     }

--- a/tests/Authentication/UsernameAndPasswordToCookieValuesTrait.php
+++ b/tests/Authentication/UsernameAndPasswordToCookieValuesTrait.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\CmlifeClient\Tests\Authentication;
+
+use ITB\CmlifeClient\Authentication\CookieValuesAuthenticator;
+use ITB\CmlifeClient\Authentication\UsernamePasswordAuthenticator;
+use ITB\CmlifeClient\Exception\AuthenticationException;
+use Symfony\Component\HttpClient\HttpClient;
+
+trait UsernameAndPasswordToCookieValuesTrait
+{
+    /**
+     * @param string $username
+     * @param string $password
+     * @return array{'sessionId': string, 'xsrfToken': string}
+     * @throws AuthenticationException
+     */
+    private function createCookieValuesFromUsernameAndPassword(string $username, string $password): array
+    {
+        $httpClient = HttpClient::create();
+
+        $usernamePasswordAuthenticator = new UsernamePasswordAuthenticator($httpClient);
+        $usernamePasswordAuthenticator->authenticate([
+            UsernamePasswordAuthenticator::CREDENTIAL_NAME_USERNAME => $username,
+            UsernamePasswordAuthenticator::CREDENTIAL_NAME_PASSWORD => $password
+        ]);
+        $authenticationHeaders = $usernamePasswordAuthenticator->getAuthenticationHeaders();
+        $authenticationCookies = explode('; ', $authenticationHeaders['Cookie']);
+        $sessionIdCookie = array_values(
+            array_filter($authenticationCookies, static function (string $cookie): bool {
+                return str_starts_with($cookie, 'SESSION');
+            })
+        )[0];
+        $sessionId = explode('=', $sessionIdCookie)[1];
+        $xsrfTokenCookie = array_values(
+            array_filter($authenticationCookies, static function (string $cookie): bool {
+                return str_starts_with($cookie, 'XSRF-TOKEN');
+            })
+        )[0];
+        $xsrfToken = explode('=', $xsrfTokenCookie)[1];
+
+        return [
+            CookieValuesAuthenticator::CREDENTIAL_NAME_SESSION_ID => $sessionId,
+            CookieValuesAuthenticator::CREDENTIAL_NAME_XSRF_TOKEN => $xsrfToken
+        ];
+    }
+}


### PR DESCRIPTION
Contrary to my assumption that the cookies never expire (which is indicated by the missing expire value of the cookies), the session id expires indeed.

To prevent issues with expired cookie values in tests, the tests are obtaining them via authentication with username and password.