### PR TITLE
Existing data is removed before new/updated data is added

### DIFF
--- a/src/CmlifeClient.php
+++ b/src/CmlifeClient.php
@@ -243,7 +243,7 @@ final class CmlifeClient implements CmlifeClientInterface
             }
             foreach ($pagedCoursesData['content'] as $courseData) {
                 $course = Course::create($courseData, $semester);
-                $this->dataStorage->getEntityManager()->persist($course);
+                $this->dataStorage->persistCourse($course);
             }
         };
 
@@ -267,7 +267,7 @@ final class CmlifeClient implements CmlifeClientInterface
             }
 
             $person = Person::create($personData, true);
-            $this->dataStorage->getEntityManager()->persist($person);
+            $this->dataStorage->persistPerson($person);
         };
 
         return $this->dataClient->fetchDataAsync(
@@ -309,7 +309,7 @@ final class CmlifeClient implements CmlifeClientInterface
             }
 
             $study = Study::create($studyData);
-            $this->dataStorage->getEntityManager()->persist($study);
+            $this->dataStorage->persistStudy($study);
         };
 
         return $this->dataClient->fetchAllDataAsync($requestDatasets, $onFailureCallback, $onSuccessCallback);
@@ -333,7 +333,7 @@ final class CmlifeClient implements CmlifeClientInterface
             }
 
             $semester = Semester::create($semesterData);
-            $this->dataStorage->getEntityManager()->persist($semester);
+            $this->dataStorage->persistSemester($semester);
         };
 
         return $this->dataClient->fetchDataAsync(

--- a/src/Storage/DataStorage.php
+++ b/src/Storage/DataStorage.php
@@ -128,4 +128,64 @@ final class DataStorage implements DataStorageInterface
     {
         return $this->studyRepository;
     }
+
+    /**
+     * @param Course $course
+     * @return void
+     * @throws ORMException
+     */
+    public function persistCourse(Course $course): void
+    {
+        $persistedCourse = $this->courseRepository->find($course->getId());
+        if (null !== $persistedCourse) {
+            $this->entityManager->remove($persistedCourse);
+        }
+
+        $this->entityManager->persist($course);
+    }
+
+    /**
+     * @param Person $person
+     * @return void
+     * @throws ORMException
+     */
+    public function persistPerson(Person $person): void
+    {
+        $persistedPerson = $this->personRepository->find($person->getUri());
+        if (null !== $persistedPerson) {
+            $this->entityManager->remove($persistedPerson);
+        }
+
+        $this->entityManager->persist($person);
+    }
+
+    /**
+     * @param Semester $semester
+     * @return void
+     * @throws ORMException
+     */
+    public function persistSemester(Semester $semester): void
+    {
+        $persistedSemester = $this->semesterRepository->find($semester->getId());
+        if (null !== $persistedSemester) {
+            $this->entityManager->remove($persistedSemester);
+        }
+
+        $this->entityManager->persist($semester);
+    }
+
+    /**
+     * @param Study $study
+     * @return void
+     * @throws ORMException
+     */
+    public function persistStudy(Study $study): void
+    {
+        $persistedStudy = $this->studyRepository->find($study->getId());
+        if (null !== $persistedStudy) {
+            $this->entityManager->remove($study);
+        }
+
+        $this->entityManager->persist($study);
+    }
 }

--- a/src/Storage/DataStorageInterface.php
+++ b/src/Storage/DataStorageInterface.php
@@ -6,6 +6,10 @@ namespace ITB\CmlifeClient\Storage;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectRepository;
+use ITB\CmlifeClient\Model\Course;
+use ITB\CmlifeClient\Model\Person;
+use ITB\CmlifeClient\Model\Semester;
+use ITB\CmlifeClient\Model\Study;
 use ITB\CmlifeClient\Storage\Repository\CourseRepository;
 use ITB\CmlifeClient\Storage\Repository\NodeRepository;
 use ITB\CmlifeClient\Storage\Repository\PersonRepository;
@@ -43,4 +47,28 @@ interface DataStorageInterface
      * @return StudyRepository
      */
     public function getStudyRepository(): StudyRepository;
+
+    /**
+     * @param Course $course
+     * @return void
+     */
+    public function persistCourse(Course $course): void;
+
+    /**
+     * @param Person $person
+     * @return void
+     */
+    public function persistPerson(Person $person): void;
+
+    /**
+     * @param Semester $semester
+     * @return void
+     */
+    public function persistSemester(Semester $semester): void;
+
+    /**
+     * @param Study $study
+     * @return void
+     */
+    public function persistStudy(Study $study): void;
 }

--- a/src/Storage/Repository/CourseRepository.php
+++ b/src/Storage/Repository/CourseRepository.php
@@ -26,6 +26,15 @@ final class CourseRepository
     }
 
     /**
+     * @param int $courseId
+     * @return Course|null
+     */
+    public function find(int $courseId): ?Course
+    {
+        return $this->entityRepository->find($courseId);
+    }
+
+    /**
      * @param LinkNode[] $linkNodes
      * @return Course[]
      * @throws CourseSearchWithLinkNodesAndSemesterFailedException

--- a/src/Storage/Repository/PersonRepository.php
+++ b/src/Storage/Repository/PersonRepository.php
@@ -25,6 +25,15 @@ final class PersonRepository
     }
 
     /**
+     * @param string $personUri
+     * @return Person|null
+     */
+    public function find(string $personUri): ?Person
+    {
+        return $this->entityRepository->find($personUri);
+    }
+
+    /**
      * @return Person
      * @throws StorageException
      */

--- a/src/Storage/Repository/StudyRepository.php
+++ b/src/Storage/Repository/StudyRepository.php
@@ -22,6 +22,15 @@ final class StudyRepository
     }
 
     /**
+     * @param int $studyId
+     * @return Study|null
+     */
+    public function find(int $studyId): ?Study
+    {
+        return $this->entityRepository->find($studyId);
+    }
+
+    /**
      * @return Study[]
      */
     public function findAll(): array


### PR DESCRIPTION
Doctrine manages entities by holding references to them and marking them internally as 'manged'. When the client receives data, new objects are always created. Doctrine conceives them as new an tries to persist them via INSERT. This leads to duplicate ID problems.

To prevent this issue, the persistence is done via `DataStorage`. The methods remove any existing entity with the same id before persisting the updated data as a new entity.