### PR TITLE
data update mechanism refactored

### DIFF
--- a/src/Model/Course.php
+++ b/src/Model/Course.php
@@ -18,11 +18,11 @@ final class Course
         #[ORM\Column(name: 'equivalence_uri', type: 'string')]
         private readonly string $equivalenceUri,
         #[ORM\Column(name: 'name', type: 'string')]
-        private readonly string $name,
+        private string $name,
         #[ORM\Column(name: 'code', type: 'string')]
-        private readonly string $code,
+        private string $code,
         #[ORM\Column(name: 'frontend_url', type: 'string')]
-        private readonly string $frontendUrl,
+        private string $frontendUrl,
         #[ORM\ManyToOne(targetEntity: Semester::class)]
         #[ORM\JoinColumn(name: 'semester_id', referencedColumnName: 'id')]
         private readonly Semester $semester
@@ -102,5 +102,16 @@ final class Course
     public function getUri(): string
     {
         return $this->uri;
+    }
+
+    /**
+     * @param Course $course
+     * @return void
+     */
+    public function update(Course $course): void
+    {
+        $this->name = $course->name;
+        $this->code = $course->code;
+        $this->frontendUrl = $course->frontendUrl;
     }
 }

--- a/src/Model/Curriculum.php
+++ b/src/Model/Curriculum.php
@@ -26,9 +26,9 @@ final class Curriculum
         #[ORM\Column(name: 'uri', type: 'string')]
         private readonly string $uri,
         #[ORM\Column(name: 'study_plan_url', type: 'string', nullable: true)]
-        private readonly ?string $studyPlanUrl,
+        private ?string $studyPlanUrl,
         #[ORM\Column(name: 'curriculum_document_url', type: 'string')]
-        private readonly string $curriculumDocumentUrl,
+        private string $curriculumDocumentUrl,
         #[ORM\ManyToOne(targetEntity: Node::class, cascade: ['persist'])]
         #[ORM\JoinColumn(name: 'root_node_id', referencedColumnName: 'id')]
         private readonly Node\RootNode $rootNode
@@ -94,5 +94,16 @@ final class Curriculum
     public function getUri(): string
     {
         return $this->uri;
+    }
+
+    /**
+     * @param Curriculum $curriculum
+     * @return void
+     */
+    public function update(Curriculum $curriculum): void
+    {
+        $this->studyPlanUrl = $curriculum->studyPlanUrl;
+        $this->curriculumDocumentUrl = $curriculum->curriculumDocumentUrl;
+        $this->rootNode->update($curriculum->rootNode);
     }
 }

--- a/src/Model/Curriculum/Node/LinkNode.php
+++ b/src/Model/Curriculum/Node/LinkNode.php
@@ -45,4 +45,16 @@ final class LinkNode extends Node
     {
         return self::TYPE;
     }
+
+    /**
+     * @param NodeInterface $node
+     * @return void
+     */
+    public function update(NodeInterface $node): void
+    {
+        parent::update($node);
+        /** @var LinkNode $node */
+
+        $this->courseEquivalenceUri = $node->courseEquivalenceUri;
+    }
 }

--- a/src/Model/Curriculum/NodeException/InvalidNodeTypeOnCreateException.php
+++ b/src/Model/Curriculum/NodeException/InvalidNodeTypeOnCreateException.php
@@ -6,14 +6,14 @@ namespace ITB\CmlifeClient\Model\Curriculum\NodeException;
 
 use RuntimeException;
 
-final class InvalidNodeTypeException extends RuntimeException
+final class InvalidNodeTypeOnCreateException extends RuntimeException
 {
     /**
      * @param string $actualNodeType
      * @param string $expectedNodeType
-     * @return InvalidNodeTypeException
+     * @return InvalidNodeTypeOnCreateException
      */
-    public static function create(string $actualNodeType, string $expectedNodeType): InvalidNodeTypeException
+    public static function create(string $actualNodeType, string $expectedNodeType): InvalidNodeTypeOnCreateException
     {
         return new self(sprintf('The created node is supposed to be of type %s, but it is of type %s.', $expectedNodeType, $actualNodeType));
     }

--- a/src/Model/Curriculum/NodeException/InvalidNodeTypeOnUpdateException.php
+++ b/src/Model/Curriculum/NodeException/InvalidNodeTypeOnUpdateException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\CmlifeClient\Model\Curriculum\NodeException;
+
+use RuntimeException;
+
+final class InvalidNodeTypeOnUpdateException extends RuntimeException
+{
+    /**
+     * @param string $actualNodeType
+     * @param string $expectedNodeType
+     * @return InvalidNodeTypeOnUpdateException
+     */
+    public static function create(string $actualNodeType, string $expectedNodeType): InvalidNodeTypeOnUpdateException
+    {
+        return new self(sprintf('The node to update is supposed to be of type %s, but it is of type %s.', $expectedNodeType, $actualNodeType));
+    }
+}

--- a/src/Model/Curriculum/NodeFactory.php
+++ b/src/Model/Curriculum/NodeFactory.php
@@ -6,11 +6,12 @@ namespace ITB\CmlifeClient\Model\Curriculum;
 
 use ITB\CmlifeClient\Model\Curriculum\Node\AssessmentNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\LinkNode;
+use ITB\CmlifeClient\Model\Curriculum\Node\ModuleNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\OfferNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\PartNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\RootNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\RuleNode;
-use ITB\CmlifeClient\Model\Curriculum\Node\ModuleNode;
+use ITB\CmlifeClient\Model\Curriculum\NodeFactoryException\UnknownNodeTypException;
 
 final class NodeFactory
 {
@@ -37,8 +38,23 @@ final class NodeFactory
             $nodeData['children'] = [];
         }
 
-        $nodeClassName = self::NODE_TYPE_TO_CLASS_MAP[strtolower($nodeData['type'])];
+        $nodeClassName = self::getNodeClassForNodeType($nodeData['type']);
 
-        return $nodeClassName::create($nodeData, $parent);
+        return call_user_func([$nodeClassName, 'create'], $nodeData, $parent);
+    }
+
+    /**
+     * @param string $nodeType
+     * @return class-string<NodeInterface>
+     */
+    public static function getNodeClassForNodeType(string $nodeType): string
+    {
+        $nodeType = strtolower($nodeType);
+
+        if (!array_key_exists($nodeType, self::NODE_TYPE_TO_CLASS_MAP)) {
+            throw UnknownNodeTypException::create($nodeType, array_keys(self::NODE_TYPE_TO_CLASS_MAP));
+        }
+
+        return self::NODE_TYPE_TO_CLASS_MAP[$nodeType];
     }
 }

--- a/src/Model/Curriculum/NodeFactoryException/UnknownNodeTypException.php
+++ b/src/Model/Curriculum/NodeFactoryException/UnknownNodeTypException.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\CmlifeClient\Model\Curriculum\NodeFactoryException;
+
+use RuntimeException;
+
+final class UnknownNodeTypException extends RuntimeException
+{
+    /**
+     * @param string $nodeType
+     * @param string[] $allowedNodeTypes
+     * @return UnknownNodeTypException
+     */
+    public static function create(string $nodeType, array $allowedNodeTypes): UnknownNodeTypException
+    {
+        return new self(sprintf('The node %s is unknown. Known node types are [%s].', $nodeType, implode(', ', $allowedNodeTypes)));
+    }
+}

--- a/src/Model/Curriculum/NodeInterface.php
+++ b/src/Model/Curriculum/NodeInterface.php
@@ -51,4 +51,10 @@ interface NodeInterface
      * @return string
      */
     public function getUri(): string;
+
+    /**
+     * @param NodeInterface $node
+     * @return void
+     */
+    public function update(NodeInterface $node): void;
 }

--- a/src/Model/Person.php
+++ b/src/Model/Person.php
@@ -21,7 +21,7 @@ final class Person
         #[ORM\Column(name: 'username', type: 'string')]
         private readonly string $username,
         #[ORM\Column(name: 'is_me', type: 'boolean')]
-        private readonly bool $isMe
+        private bool $isMe
     ) {
     }
 
@@ -60,5 +60,14 @@ final class Person
     public function isMe(): bool
     {
         return $this->isMe;
+    }
+
+    /**
+     * @param Person $person
+     * @return void
+     */
+    public function update(Person $person): void
+    {
+        $this->isMe = $person->isMe;
     }
 }

--- a/src/Model/Semester.php
+++ b/src/Model/Semester.php
@@ -22,9 +22,9 @@ final class Semester
         #[ORM\Column(name: 'uri', type: 'string')]
         private readonly string $uri,
         #[ORM\Column(name: 'name', type: 'string')]
-        private readonly string $name,
+        private string $name,
         #[ORM\Column(name: 'is_current', type: 'boolean')]
-        private readonly bool $isCurrent
+        private bool $isCurrent
     ) {
     }
 
@@ -72,5 +72,15 @@ final class Semester
     public function isCurrent(): bool
     {
         return $this->isCurrent;
+    }
+
+    /**
+     * @param Semester $semester
+     * @return void
+     */
+    public function update(Semester $semester): void
+    {
+        $this->name = $semester->name;
+        $this->isCurrent = $semester->isCurrent;
     }
 }

--- a/src/Model/Study.php
+++ b/src/Model/Study.php
@@ -23,9 +23,9 @@ final class Study
         #[ORM\Column(name: 'uri', type: 'string')]
         private readonly string $uri,
         #[ORM\Column(name: 'program_subject', type: 'string')]
-        private readonly string $programSubject,
+        private string $programSubject,
         #[ORM\Column(name: 'program_degree', type: 'string')]
-        private readonly string $programDegree,
+        private string $programDegree,
         #[ORM\OneToOne(targetEntity: Curriculum::class, cascade: ['all'], orphanRemoval: true)]
         #[ORM\JoinColumn(name: 'curriculum_id', referencedColumnName: 'id')]
         private readonly Curriculum $curriculum
@@ -86,5 +86,16 @@ final class Study
     public function getUri(): string
     {
         return $this->uri;
+    }
+
+    /**
+     * @param Study $study
+     * @return void
+     */
+    public function update(Study $study): void
+    {
+        $this->programSubject = $study->programSubject;
+        $this->programDegree = $study->programDegree;
+        $this->curriculum->update($study->curriculum);
     }
 }

--- a/src/Storage/DataStorage.php
+++ b/src/Storage/DataStorage.php
@@ -7,6 +7,7 @@ namespace ITB\CmlifeClient\Storage;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
 use Doctrine\ORM\ORMSetup;
 use Doctrine\ORM\Tools\SchemaTool;
 use Exception;
@@ -82,6 +83,16 @@ final class DataStorage implements DataStorageInterface
     }
 
     /**
+     * @return void
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function flush(): void
+    {
+        $this->entityManager->flush();
+    }
+
+    /**
      * @return CourseRepository
      */
     public function getCourseRepository(): CourseRepository
@@ -138,7 +149,8 @@ final class DataStorage implements DataStorageInterface
     {
         $persistedCourse = $this->courseRepository->find($course->getId());
         if (null !== $persistedCourse) {
-            $this->entityManager->remove($persistedCourse);
+            $persistedCourse->update($course);
+            $course = $persistedCourse;
         }
 
         $this->entityManager->persist($course);
@@ -153,7 +165,8 @@ final class DataStorage implements DataStorageInterface
     {
         $persistedPerson = $this->personRepository->find($person->getUri());
         if (null !== $persistedPerson) {
-            $this->entityManager->remove($persistedPerson);
+            $persistedPerson->update($person);
+            $person = $persistedPerson;
         }
 
         $this->entityManager->persist($person);
@@ -168,7 +181,8 @@ final class DataStorage implements DataStorageInterface
     {
         $persistedSemester = $this->semesterRepository->find($semester->getId());
         if (null !== $persistedSemester) {
-            $this->entityManager->remove($persistedSemester);
+            $persistedSemester->update($semester);
+            $semester = $persistedSemester;
         }
 
         $this->entityManager->persist($semester);
@@ -183,7 +197,8 @@ final class DataStorage implements DataStorageInterface
     {
         $persistedStudy = $this->studyRepository->find($study->getId());
         if (null !== $persistedStudy) {
-            $this->entityManager->remove($study);
+            $persistedStudy->update($study);
+            $study = $persistedStudy;
         }
 
         $this->entityManager->persist($study);

--- a/src/Storage/DataStorageInterface.php
+++ b/src/Storage/DataStorageInterface.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace ITB\CmlifeClient\Storage;
 
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\Persistence\ObjectRepository;
 use ITB\CmlifeClient\Model\Course;
 use ITB\CmlifeClient\Model\Person;
 use ITB\CmlifeClient\Model\Semester;
@@ -18,6 +17,11 @@ use ITB\CmlifeClient\Storage\Repository\StudyRepository;
 
 interface DataStorageInterface
 {
+    /**
+     * @return void
+     */
+    public function flush(): void;
+
     /**
      * @return CourseRepository
      */

--- a/src/Storage/Repository/CourseRepository.php
+++ b/src/Storage/Repository/CourseRepository.php
@@ -35,6 +35,14 @@ final class CourseRepository
     }
 
     /**
+     * @return Course[]
+     */
+    public function findAll(): array
+    {
+        return $this->entityRepository->findAll();
+    }
+
+    /**
      * @param LinkNode[] $linkNodes
      * @return Course[]
      * @throws CourseSearchWithLinkNodesAndSemesterFailedException

--- a/src/Storage/Repository/NodeRepository.php
+++ b/src/Storage/Repository/NodeRepository.php
@@ -7,7 +7,6 @@ namespace ITB\CmlifeClient\Storage\Repository;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\EntityRepository;
 use Exception;
-use ITB\CmlifeClient\Exception\StorageException;
 use ITB\CmlifeClient\Model\Curriculum\Node;
 use ITB\CmlifeClient\Model\Curriculum\NodeInterface;
 use ITB\CmlifeClient\Model\Study;

--- a/src/Storage/Repository/PersonRepository.php
+++ b/src/Storage/Repository/PersonRepository.php
@@ -34,6 +34,14 @@ final class PersonRepository
     }
 
     /**
+     * @return Person[]
+     */
+    public function findAll(): array
+    {
+        return $this->entityRepository->findAll();
+    }
+
+    /**
      * @return Person
      * @throws StorageException
      */

--- a/tests/Fixtures/course.php
+++ b/tests/Fixtures/course.php
@@ -68,3 +68,16 @@ function getCourseData(): array
         'uri' => '//ubt@cmco/api/courses/308609',
     ];
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function getCourseUpdateData(): array
+{
+    $data = getCourseData();
+    $data['nameDe'] = 'Vergangene Themen der Umweltgeochemie';
+    $data['code'] = '1337';
+    $data['frontendUrl'] = 'https://666.666.666.666';
+
+    return $data;
+}

--- a/tests/Fixtures/current_semester.php
+++ b/tests/Fixtures/current_semester.php
@@ -23,3 +23,15 @@ function getCurrentSemesterData(): array
         'uri' => '//ubt@cmco/api/semesters/243',
     ];
 }
+
+/**
+ * @return array<string, mixed>
+ */
+function getCurrentSemesterUpdateData(): array
+{
+    $data = getCurrentSemesterData();
+    $data['name'] = 'Wintersemester 2022/23 (aktualisiert)';
+    $data['current'] = false;
+
+    return $data;
+}

--- a/tests/Fixtures/study.php
+++ b/tests/Fixtures/study.php
@@ -333,7 +333,90 @@ function getStudyData(): array
 /**
  * @return array<string, mixed>
  */
+function getRootNodeDataFromCurriculum(): array
+{
+    return getCurriculumData()['root'];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function getRootNodeUpdateDataWithIdenticalNodes(): array
+{
+    $data = getRootNodeDataFromCurriculum();
+    $data['nameDe'] = 'Geänderter Name 3';
+    $data['children'][0]['nameDe'] = 'Geänderter Name 1';
+    $data['children'][0]['children'][0]['nameDe'] = 'Geänderter Name 2';
+    $data['children'][0]['children'][0]['children'][0]['nameDe'] = 'Geänderter Name 3';
+
+    return $data;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function getRootNodeUpdateDataWithRemovedChildOnSecondLevel(): array
+{
+    $data = getRootNodeDataFromCurriculum();
+    $data['children'][0]['children'] = [];
+
+    return $data;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function getRootNodeUpdateDataWithAddedChildOnSecondLevel(): array
+{
+    $data = getRootNodeDataFromCurriculum();
+
+    include_once __DIR__ . '/node/link_node.php';
+    $data['children'][0]['children'][] = getLinkNodeData();
+
+    return $data;
+}
+
+/**
+ * @return array<string, mixed>
+ */
 function getCurriculumData(): array
 {
     return getStudyData()['curriculum'];
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function getCurriculumDataWithWrongRootNodeType(): array
+{
+    $data = getStudyData()['curriculum'];
+    $data['root']['type'] = 'LINK';
+
+    return $data;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function getStudyUpdateData(): array
+{
+    $data = getStudyData();
+    $data['program']['subject']['nameDe'] = 'Angewandte finstere Chaoswissenschaft';
+    $data['program']['degreeGoal']['nameDe'] = 'Bachelor of Sinister Disaster';
+    $data['curriculum']['curriculumDocumentUrl'] = 'https://666.666.666.666';
+
+    return $data;
+}
+
+/**
+ * @return array<string, mixed>
+ */
+function getCurriculumUpdateData(): array
+{
+    $data = getCurriculumData();
+    $data['studyPlanUrl'] = 'https://666.666.666.666';
+    $data['curriculumDocumentUrl'] = 'https://777.777.777.777';
+    $data['root']['nameDe'] = '66.06.666';
+
+    return $data;
 }

--- a/tests/Model/CourseTest.php
+++ b/tests/Model/CourseTest.php
@@ -104,6 +104,20 @@ final class CourseTest extends TestCase
     /**
      * @return Generator
      */
+    public function provideForTestUpdate(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/current_semester.php';
+        $semester = Semester::create(getCurrentSemesterData());
+        include_once __DIR__ . '/../Fixtures/course.php';
+        $course = Course::create(getCourseData(), $semester);
+        $courseUpdate = Course::create(getCourseUpdateData(), $semester);
+
+        yield [$course, $courseUpdate];
+    }
+
+    /**
+     * @return Generator
+     */
     public function provideFotTestGetCode(): Generator
     {
         include_once __DIR__ . '/../Fixtures/current_semester.php';
@@ -210,5 +224,24 @@ final class CourseTest extends TestCase
     public function testGetUri(Course $course, string $expectedUri): void
     {
         $this->assertEquals($expectedUri, $course->getUri());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdate
+     *
+     * @param Course $course
+     * @param Course $courseUpdate
+     * @return void
+     */
+    public function testUpdate(Course $course, Course $courseUpdate): void
+    {
+        $this->assertNotEquals($courseUpdate->getName(), $course->getName());
+        $this->assertNotEquals($courseUpdate->getCode(), $course->getCode());
+        $this->assertNotEquals($courseUpdate->getFrontendUrl(), $course->getFrontendUrl());
+
+        $course->update($courseUpdate);
+        $this->assertEquals($courseUpdate->getName(), $course->getName());
+        $this->assertEquals($courseUpdate->getCode(), $course->getCode());
+        $this->assertEquals($courseUpdate->getFrontendUrl(), $course->getFrontendUrl());
     }
 }

--- a/tests/Model/Curriculum/NodeFactoryTest.php
+++ b/tests/Model/Curriculum/NodeFactoryTest.php
@@ -12,6 +12,7 @@ use ITB\CmlifeClient\Model\Curriculum\Node\OfferNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\RootNode;
 use ITB\CmlifeClient\Model\Curriculum\Node\RuleNode;
 use ITB\CmlifeClient\Model\Curriculum\NodeFactory;
+use ITB\CmlifeClient\Model\Curriculum\NodeFactoryException\UnknownNodeTypException;
 use PHPUnit\Framework\TestCase;
 
 final class NodeFactoryTest extends TestCase
@@ -41,6 +42,29 @@ final class NodeFactoryTest extends TestCase
     }
 
     /**
+     * @return Generator
+     */
+    public function provideForTestGetNodeClassForNodeType(): Generator
+    {
+        yield 'assessment node' => [AssessmentNode::TYPE, AssessmentNode::class];
+        yield 'link node' => [LinkNode::TYPE, LinkNode::class];
+        yield 'module node' => [ModuleNode::TYPE, ModuleNode::class];
+        yield 'offer node' => [OfferNode::TYPE, OfferNode::class];
+        yield 'root node' => [RootNode::TYPE, RootNode::class];
+        yield 'rule node' => [RuleNode::TYPE, RuleNode::class];
+
+        yield 'root node with upper characters' => [strtoupper(RootNode::TYPE), RootNode::class];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestGetNodeClassForNodeTypeWithInvalidType(): Generator
+    {
+        yield ['I am a test!'];
+    }
+
+    /**
      * @dataProvider provideForTestCreateNode
      *
      * @param array<string, mixed> $nodeData
@@ -51,5 +75,29 @@ final class NodeFactoryTest extends TestCase
     {
         $node = NodeFactory::createNode($nodeData);
         $this->assertInstanceOf($expectedNodeType, $node);
+    }
+
+    /**
+     * @dataProvider provideForTestGetNodeClassForNodeType
+     *
+     * @param string $nodeType
+     * @param string $expectedNodeClass
+     * @return void
+     */
+    public function testGetNodeClassForNodeType(string $nodeType, string $expectedNodeClass): void
+    {
+        $this->assertEquals($expectedNodeClass, NodeFactory::getNodeClassForNodeType($nodeType));
+    }
+
+    /**
+     * @dataProvider provideForTestGetNodeClassForNodeTypeWithInvalidType
+     *
+     * @param string $nodeType
+     * @return void
+     */
+    public function testGetNodeClassForNodeTypeWithInvalidType(string $nodeType): void
+    {
+        $this->expectException(UnknownNodeTypException::class);
+        NodeFactory::getNodeClassForNodeType($nodeType);
     }
 }

--- a/tests/Model/Curriculum/NodeTest.php
+++ b/tests/Model/Curriculum/NodeTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\CmlifeClient\Tests\Model\Curriculum;
+
+use Generator;
+use ITB\CmlifeClient\Model\Curriculum\Node\LinkNode;
+use ITB\CmlifeClient\Model\Curriculum\Node\RootNode;
+use ITB\CmlifeClient\Model\Curriculum\NodeException\InvalidNodeTypeOnCreateException;
+use ITB\CmlifeClient\Model\Curriculum\NodeException\InvalidNodeTypeOnUpdateException;
+use ITB\CmlifeClient\Model\Curriculum\NodeInterface;
+use LogicException;
+use PHPUnit\Framework\TestCase;
+
+final class NodeTest extends TestCase
+{
+    /**
+     * @return Generator
+     */
+    public function provideForTestBelongsToRootNode(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+
+        // This walkthrough to the leaf node works because the test node tree has no branches.
+        $leafNode = $rootNode;
+        /** @phpstan-ignore-next-line */
+        while (0 !== count($leafNode->getChildren())) {
+            /** @phpstan-ignore-next-line */
+            $leafNode = $leafNode->getChildren()->first();
+        }
+        yield [$leafNode, $rootNode, true];
+
+        include_once __DIR__ . '/../../Fixtures/node/link_node.php';
+        $leafNode = LinkNode::create(getLinkNodeData());
+        yield [$leafNode, $rootNode, false];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestCreateRootNode(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+
+        yield [getRootNodeDataFromCurriculum()];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestCreateWithInvalidNodeType(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/node/link_node.php';
+
+        yield [getLinkNodeData()];
+    }
+
+    public function provideForTestGetChildren(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+        $childrenCount = count(getRootNodeDataFromCurriculum()['children']);
+
+        yield [$rootNode, $childrenCount];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestGetId(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+
+        yield [$rootNode, getRootNodeDataFromCurriculum()['id']];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestGetName(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+
+        yield [$rootNode, getRootNodeDataFromCurriculum()['nameDe']];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestGetParent(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+        $childNode = $rootNode->getChildren()->first();
+
+        yield 'root' => [$rootNode, null];
+        yield 'child of root' => [$childNode, $rootNode];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestGetUri(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+
+        yield [$rootNode, getRootNodeDataFromCurriculum()['uri']];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestUpdateWithAddedChildOnSecondLevel(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+        $rootNodeUpdate = RootNode::create(getRootNodeUpdateDataWithAddedChildOnSecondLevel());
+
+        yield [$rootNode, $rootNodeUpdate];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestUpdateWithIdenticalNodes(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+        $rootNodeUpdate = RootNode::create(getRootNodeUpdateDataWithIdenticalNodes());
+
+        yield [$rootNode, $rootNodeUpdate];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestUpdateWithRemovedChildOnSecondLevel(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+        $rootNodeUpdate = RootNode::create(getRootNodeUpdateDataWithRemovedChildOnSecondLevel());
+
+        yield [$rootNode, $rootNodeUpdate];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestUpdateWithWrongUpdateType(): Generator
+    {
+        include_once __DIR__ . '/../../Fixtures/study.php';
+        $rootNode = RootNode::create(getRootNodeDataFromCurriculum());
+        include_once __DIR__ . '/../../Fixtures/node/link_node.php';
+        $nodeUpdate = LinkNode::create(getLinkNodeData());
+
+        yield [$rootNode, $nodeUpdate];
+    }
+
+    /**
+     * @dataProvider provideForTestBelongsToRootNode
+     *
+     * @param NodeInterface $leafNode
+     * @param RootNode $rootNode
+     * @param bool $expectedBelongsTo
+     * @return void
+     */
+    public function testBelongsToRootNode(NodeInterface $leafNode, RootNode $rootNode, bool $expectedBelongsTo): void
+    {
+        $this->assertEquals($expectedBelongsTo, $leafNode->belongsToRootNode($rootNode));
+    }
+
+    /**
+     * @dataProvider provideForTestCreateRootNode
+     *
+     * @param array<string, mixed> $rootNodeData
+     * @return void
+     */
+    public function testCreateRootNode(array $rootNodeData): void
+    {
+        $rootNode = RootNode::create($rootNodeData);
+        $this->assertInstanceOf(RootNode::class, $rootNode);
+    }
+
+    /**
+     * @dataProvider provideForTestCreateWithInvalidNodeType
+     *
+     * @param array<string, mixed> $linkNodeData
+     * @return void
+     */
+    public function testCreateWithInvalidNodeType(array $linkNodeData): void
+    {
+        $this->expectException(InvalidNodeTypeOnCreateException::class);
+        RootNode::create($linkNodeData);
+    }
+
+    /**
+     * @dataProvider provideForTestGetChildren
+     *
+     * @param RootNode $node
+     * @param int $expectedChildrenCount
+     * @return void
+     */
+    public function testGetChildren(RootNode $node, int $expectedChildrenCount): void
+    {
+        $this->assertEquals($expectedChildrenCount, $node->getChildren()->count());
+    }
+
+    /**
+     * @dataProvider provideForTestGetId
+     *
+     * @param RootNode $node
+     * @param int $expectedId
+     * @return void
+     */
+    public function testGetId(RootNode $node, int $expectedId): void
+    {
+        $this->assertEquals($expectedId, $node->getId());
+    }
+
+    /**
+     * @dataProvider provideForTestGetName
+     *
+     * @param RootNode $node
+     * @param string $expectedName
+     * @return void
+     */
+    public function testGetName(RootNode $node, string $expectedName): void
+    {
+        $this->assertEquals($expectedName, $node->getName());
+    }
+
+    /**
+     * @dataProvider provideForTestGetParent
+     *
+     * @param NodeInterface $node
+     * @param NodeInterface|null $expectedParent
+     * @return void
+     */
+    public function testGetParent(NodeInterface $node, ?NodeInterface $expectedParent): void
+    {
+        $this->assertEquals($expectedParent, $node->getParent());
+    }
+
+    /**
+     * @dataProvider provideForTestGetUri
+     *
+     * @param RootNode $node
+     * @param string $expectedUri
+     * @return void
+     */
+    public function testGetUri(RootNode $node, string $expectedUri): void
+    {
+        $this->assertEquals($expectedUri, $node->getUri());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdateWithAddedChildOnSecondLevel
+     *
+     * @param RootNode $rootNode
+     * @param RootNode $rootNodeUpdate
+     * @return void
+     */
+    public function testUpdateWithAddedChildOnSecondLevel(RootNode $rootNode, RootNode $rootNodeUpdate): void
+    {
+        // Ensure that the test does not run on nodes without children.
+        if (0 === $rootNode->getChildren()->count()) {
+            throw new LogicException('This test should not run on nodes without children as it\'s supposed to test deep updates.');
+        }
+
+        $firstLevelNode = $rootNode->getChildren()->first();
+        $firstLevelNodeUpdate = $rootNodeUpdate->getChildren()->first();
+
+        /** @phpstan-ignore-next-line */
+        $this->assertNotEquals($firstLevelNodeUpdate->getChildren()->count(), $firstLevelNode->getChildren()->count());
+
+        $rootNode->update($rootNodeUpdate);
+
+        /** @phpstan-ignore-next-line */
+        $this->assertEquals($firstLevelNodeUpdate->getChildren()->count(), $firstLevelNode->getChildren()->count());
+        /** @phpstan-ignore-next-line */
+        $this->assertInstanceOf(LinkNode::class, $firstLevelNode->getChildren()->last());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdateWithIdenticalNodes
+     *
+     * @param RootNode $rootNode
+     * @param RootNode $rootNodeUpdate
+     * @return void
+     */
+    public function testUpdateWithIdenticalNodes(RootNode $rootNode, RootNode $rootNodeUpdate): void
+    {
+        // Ensure that the test does not run on nodes without children.
+        if (0 === $rootNode->getChildren()->count()) {
+            throw new LogicException('This test should not run on nodes without children as it\'s supposed to test deep updates.');
+        }
+
+        $depth = 0;
+        $leafNode = $rootNode;
+        $leafNodeUpdate = $rootNodeUpdate;
+        do {
+            /** @phpstan-ignore-next-line */
+            $this->assertNotEquals($leafNodeUpdate->getName(), $leafNode->getName());
+
+            /** @phpstan-ignore-next-line */
+            $leafNode = $leafNode->getChildren()->first();
+            /** @phpstan-ignore-next-line */
+            $leafNodeUpdate = $leafNodeUpdate->getChildren()->first();
+
+            $depth++;
+
+            /** @phpstan-ignore-next-line */
+        } while (0 !== count($leafNode->getChildren()) && 0 !== count($leafNodeUpdate->getChildren()));
+
+        $rootNode->update($rootNodeUpdate);
+
+        $depthAfterUpdate = 0;
+        $leafNode = $rootNode;
+        $leafNodeUpdate = $rootNodeUpdate;
+        do {
+            /** @phpstan-ignore-next-line */
+            $this->assertEquals($leafNodeUpdate->getName(), $leafNode->getName());
+
+            /** @phpstan-ignore-next-line */
+            $leafNode = $leafNode->getChildren()->first();
+            /** @phpstan-ignore-next-line */
+            $leafNodeUpdate = $leafNodeUpdate->getChildren()->first();
+
+            $depthAfterUpdate++;
+
+            /** @phpstan-ignore-next-line */
+        } while (0 !== count($leafNode->getChildren()) && 0 !== count($leafNodeUpdate->getChildren()));
+
+        $this->assertEquals($depthAfterUpdate, $depth);
+    }
+
+    /**
+     * @dataProvider provideForTestUpdateWithRemovedChildOnSecondLevel
+     *
+     * @param RootNode $rootNode
+     * @param RootNode $rootNodeUpdate
+     * @return void
+     */
+    public function testUpdateWithRemovedChildOnSecondLevel(RootNode $rootNode, RootNode $rootNodeUpdate): void
+    {
+        // Ensure that the test does not run on nodes without children.
+        if (0 === $rootNode->getChildren()->count()) {
+            throw new LogicException('This test should not run on nodes without children as it\'s supposed to test deep updates.');
+        }
+
+        $firstLevelNode = $rootNode->getChildren()->first();
+        $firstLevelNodeUpdate = $rootNodeUpdate->getChildren()->first();
+
+        /** @phpstan-ignore-next-line */
+        $this->assertNotEquals($firstLevelNodeUpdate->getChildren()->count(), $firstLevelNode->getChildren()->count());
+
+        $rootNode->update($rootNodeUpdate);
+
+        /** @phpstan-ignore-next-line */
+        $this->assertEquals($firstLevelNodeUpdate->getChildren()->count(), $firstLevelNode->getChildren()->count());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdateWithWrongUpdateType
+     *
+     * @param RootNode $rootNode
+     * @param LinkNode $nodeUpdate
+     * @return void
+     */
+    public function testUpdateWithWrongUpdateType(RootNode $rootNode, LinkNode $nodeUpdate): void
+    {
+        $this->expectException(InvalidNodeTypeOnUpdateException::class);
+        $rootNode->update($nodeUpdate);
+    }
+}

--- a/tests/Model/CurriculumTest.php
+++ b/tests/Model/CurriculumTest.php
@@ -6,10 +6,33 @@ namespace ITB\CmlifeClient\Tests\Model;
 
 use Generator;
 use ITB\CmlifeClient\Model\Curriculum;
+use ITB\CmlifeClient\Model\Person;
+use LogicException;
 use PHPUnit\Framework\TestCase;
 
 final class CurriculumTest extends TestCase
 {
+    /**
+     * @return Generator
+     */
+    public function provideForTestCreateCurriculum(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+
+        yield [getCurriculumData()];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestCreateCurriculumWithWrongRootNodeType(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+        $wrongNodeType = getCurriculumDataWithWrongRootNodeType()['root']['type'];
+
+        yield [getCurriculumDataWithWrongRootNodeType(), Curriculum\NodeFactory::NODE_TYPE_TO_CLASS_MAP[strtolower($wrongNodeType)]];
+    }
+
     /**
      * @return Generator
      */
@@ -35,12 +58,73 @@ final class CurriculumTest extends TestCase
     /**
      * @return Generator
      */
+    public function provideForTestGetRootNode(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+        $curriculum = Curriculum::create(getCurriculumData());
+
+        yield [$curriculum, getCurriculumData()['root']['id']];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestGetStudyPlanUrl(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+        $curriculum = Curriculum::create(getCurriculumData());
+
+        yield [$curriculum, getCurriculumData()['studyPlanUrl']];
+    }
+
+    /**
+     * @return Generator
+     */
     public function provideForTestGetUri(): Generator
     {
         include_once __DIR__ . '/../Fixtures/study.php';
         $curriculum = Curriculum::create(getCurriculumData());
 
         yield [$curriculum, getCurriculumData()['uri']];
+    }
+
+    /**
+     * @return Generator
+     */
+    public function provideForTestUpdate(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+        $curriculum = Curriculum::create(getCurriculumData());
+        $curriculumUpdate = Curriculum::create(getCurriculumUpdateData());
+
+        yield [$curriculum, $curriculumUpdate];
+    }
+
+    /**
+     * @dataProvider provideForTestCreateCurriculum
+     *
+     * @param array<string, mixed> $curriculumData
+     * @return void
+     */
+    public function testCreateCurriculum(array $curriculumData): void
+    {
+        $curriculum = Curriculum::create($curriculumData);
+
+        $this->assertInstanceOf(Curriculum::class, $curriculum);
+    }
+
+    /**
+     * @dataProvider provideForTestCreateCurriculumWithWrongRootNodeType
+     *
+     * @param array<string, mixed> $curriculumData
+     * @param string $wrongNodeType
+     * @return void
+     */
+    public function testCreateCurriculumWithWrongRootNodeType(array $curriculumData, string $wrongNodeType): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(sprintf('The root of the curriculums node tree should always be a root node, but it is a %s', $wrongNodeType));
+        Curriculum::create($curriculumData);
     }
 
     /**
@@ -56,6 +140,18 @@ final class CurriculumTest extends TestCase
     }
 
     /**
+     * @dataProvider provideForTestGetRootNode
+     *
+     * @param Curriculum $curriculum
+     * @param int $expectedRootNodeId
+     * @return void
+     */
+    public function testGetGetRootNode(Curriculum $curriculum, int $expectedRootNodeId): void
+    {
+        $this->assertEquals($expectedRootNodeId, $curriculum->getRootNode()->getId());
+    }
+
+    /**
      * @dataProvider provideForTestGetId
      *
      * @param Curriculum $curriculum
@@ -65,6 +161,18 @@ final class CurriculumTest extends TestCase
     public function testGetId(Curriculum $curriculum, int $expectedId): void
     {
         $this->assertEquals($expectedId, $curriculum->getId());
+    }
+
+    /**
+     * @dataProvider provideForTestGetStudyPlanUrl
+     *
+     * @param Curriculum $curriculum
+     * @param string $expectedStudyPlanUrl
+     * @return void
+     */
+    public function testGetStudyPlanUrl(Curriculum $curriculum, string $expectedStudyPlanUrl): void
+    {
+        $this->assertEquals($expectedStudyPlanUrl, $curriculum->getStudyPlanUrl());
     }
 
     /**
@@ -80,48 +188,22 @@ final class CurriculumTest extends TestCase
     }
 
     /**
-     * @return Generator
-     */
-    public function provideForTestGetRootNode(): Generator
-    {
-        include_once __DIR__ . '/../Fixtures/study.php';
-        $curriculum = Curriculum::create(getCurriculumData());
-
-        yield [$curriculum, getCurriculumData()['root']['id']];
-    }
-
-    /**
-     * @dataProvider provideForTestGetRootNode
+     * @dataProvider provideForTestUpdate
      *
      * @param Curriculum $curriculum
-     * @param int $expectedRootNodeId
+     * @param Curriculum $curriculumUpdate
      * @return void
      */
-    public function testGetGetRootNode(Curriculum $curriculum, int $expectedRootNodeId): void
+    public function testUpdate(Curriculum $curriculum, Curriculum $curriculumUpdate): void
     {
-        $this->assertEquals($expectedRootNodeId, $curriculum->getRootNode()->getId());
-    }
+        $this->assertNotEquals($curriculumUpdate->getStudyPlanUrl(), $curriculum->getStudyPlanUrl());
+        $this->assertNotEquals($curriculumUpdate->getCurriculumDocumentUrl(), $curriculum->getCurriculumDocumentUrl());
+        $this->assertNotEquals($curriculumUpdate->getRootNode()->getName(), $curriculum->getRootNode()->getName());
 
-    /**
-     * @return Generator
-     */
-    public function provideForTestGetStudyPlanUrl(): Generator
-    {
-        include_once __DIR__ . '/../Fixtures/study.php';
-        $curriculum = Curriculum::create(getCurriculumData());
+        $curriculum->update($curriculumUpdate);
 
-        yield [$curriculum, getCurriculumData()['studyPlanUrl']];
-    }
-
-    /**
-     * @dataProvider provideForTestGetStudyPlanUrl
-     *
-     * @param Curriculum $curriculum
-     * @param string $expectedStudyPlanUrl
-     * @return void
-     */
-    public function testGetStudyPlanUrl(Curriculum $curriculum, string $expectedStudyPlanUrl): void
-    {
-        $this->assertEquals($expectedStudyPlanUrl, $curriculum->getStudyPlanUrl());
+        $this->assertEquals($curriculumUpdate->getStudyPlanUrl(), $curriculum->getStudyPlanUrl());
+        $this->assertEquals($curriculumUpdate->getCurriculumDocumentUrl(), $curriculum->getCurriculumDocumentUrl());
+        $this->assertEquals($curriculumUpdate->getRootNode()->getName(), $curriculum->getRootNode()->getName());
     }
 }

--- a/tests/Model/PersonTest.php
+++ b/tests/Model/PersonTest.php
@@ -65,6 +65,18 @@ final class PersonTest extends TestCase
     }
 
     /**
+     * @return Generator
+     */
+    public function provideForTestUpdate(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/me.php';
+        $me = Person::create(getPersonMeData(), true);
+        $meUpdate = Person::create(getPersonMeData(), false);
+
+        yield [$me, $meUpdate];
+    }
+
+    /**
      * @dataProvider provideForTestCreatePerson
      *
      * @param array<string, mixed> $personData
@@ -112,5 +124,20 @@ final class PersonTest extends TestCase
     public function testGetUsername(Person $person, string $expectedUsername): void
     {
         $this->assertEquals($expectedUsername, $person->getUsername());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdate
+     *
+     * @param Person $person
+     * @param Person $personUpdate
+     * @return void
+     */
+    public function testUpdate(Person $person, Person $personUpdate): void
+    {
+        $this->assertNotEquals($personUpdate->isMe(), $person->isMe());
+
+        $person->update($personUpdate);
+        $this->assertEquals($personUpdate->isMe(), $person->isMe());
     }
 }

--- a/tests/Model/SemesterTest.php
+++ b/tests/Model/SemesterTest.php
@@ -74,6 +74,18 @@ final class SemesterTest extends TestCase
     }
 
     /**
+     * @return Generator
+     */
+    public function provideForTestUpdate(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/current_semester.php';
+        $currentSemester = Semester::create(getCurrentSemesterData());
+        $currentSemesterUpdate = Semester::create(getCurrentSemesterUpdateData());
+
+        yield [$currentSemester, $currentSemesterUpdate];
+    }
+
+    /**
      * @dataProvider provideForTestCreateCurrentSemester
      *
      * @param array<string, mixed> $semesterData
@@ -132,5 +144,22 @@ final class SemesterTest extends TestCase
     public function testIsCurrent(Semester $semester, bool $expectedIsCurrent): void
     {
         $this->assertEquals($expectedIsCurrent, $semester->isCurrent());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdate
+     *
+     * @param Semester $semester
+     * @param Semester $semesterUpdate
+     * @return void
+     */
+    public function testUpdate(Semester $semester, Semester $semesterUpdate): void
+    {
+        $this->assertNotEquals($semesterUpdate->getName(), $semester->getName());
+        $this->assertNotEquals($semesterUpdate->isCurrent(), $semester->isCurrent());
+
+        $semester->update($semesterUpdate);
+        $this->assertEquals($semesterUpdate->getName(), $semester->getName());
+        $this->assertEquals($semesterUpdate->isCurrent(), $semester->isCurrent());
     }
 }

--- a/tests/Model/StudyTest.php
+++ b/tests/Model/StudyTest.php
@@ -76,6 +76,18 @@ final class StudyTest extends TestCase
     }
 
     /**
+     * @return Generator
+     */
+    public function provideForTestUpdate(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+        $study = Study::create(getStudyData());
+        $studyUpdate = Study::create(getStudyUpdateData());
+
+        yield [$study, $studyUpdate];
+    }
+
+    /**
      * @dataProvider provideForTestCreateStudy
      *
      * @param array<string, mixed> $studyData
@@ -113,18 +125,6 @@ final class StudyTest extends TestCase
     }
 
     /**
-     * @dataProvider provideForTestGetUri
-     *
-     * @param Study $study
-     * @param string $expectedUri
-     * @return void
-     */
-    public function testGetUri(Study $study, string $expectedUri): void
-    {
-        $this->assertEquals($expectedUri, $study->getUri());
-    }
-
-    /**
      * @dataProvider provideForTestGetProgramDegree
      *
      * @param Study $study
@@ -146,5 +146,36 @@ final class StudyTest extends TestCase
     public function testGetProgramSubject(Study $study, string $expectedProgramSubject): void
     {
         $this->assertEquals($expectedProgramSubject, $study->getProgramSubject());
+    }
+
+    /**
+     * @dataProvider provideForTestGetUri
+     *
+     * @param Study $study
+     * @param string $expectedUri
+     * @return void
+     */
+    public function testGetUri(Study $study, string $expectedUri): void
+    {
+        $this->assertEquals($expectedUri, $study->getUri());
+    }
+
+    /**
+     * @dataProvider provideForTestUpdate
+     *
+     * @param Study $study
+     * @param Study $studyUpdate
+     * @return void
+     */
+    public function testUpdate(Study $study, Study $studyUpdate): void
+    {
+        $this->assertNotEquals($studyUpdate->getProgramSubject(), $study->getProgramSubject());
+        $this->assertNotEquals($studyUpdate->getProgramDegree(), $study->getProgramDegree());
+        $this->assertNotEquals($studyUpdate->getCurriculum()->getCurriculumDocumentUrl(), $study->getCurriculum()->getCurriculumDocumentUrl());
+
+        $study->update($studyUpdate);
+        $this->assertEquals($studyUpdate->getProgramSubject(), $study->getProgramSubject());
+        $this->assertEquals($studyUpdate->getProgramDegree(), $study->getProgramDegree());
+        $this->assertEquals($studyUpdate->getCurriculum()->getCurriculumDocumentUrl(), $study->getCurriculum()->getCurriculumDocumentUrl());
     }
 }

--- a/tests/Storage/DataStorageTest.php
+++ b/tests/Storage/DataStorageTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ITB\CmlifeClient\Tests\Storage;
+
+use Doctrine\ORM\Exception\ORMException;
+use Doctrine\ORM\OptimisticLockException;
+use Generator;
+use ITB\CmlifeClient\Exception\StorageException;
+use ITB\CmlifeClient\Model\Course;
+use ITB\CmlifeClient\Model\Person;
+use ITB\CmlifeClient\Model\Semester;
+use ITB\CmlifeClient\Model\Study;
+use ITB\CmlifeClient\Storage\DataStorage;
+use PHPUnit\Framework\TestCase;
+
+final class DataStorageTest extends TestCase
+{
+    /**
+     * @return Generator
+     * @throws StorageException
+     */
+    public function provideForTestPersistCourse(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/current_semester.php';
+        $semester = Semester::create(getCurrentSemesterData());
+        include_once __DIR__ . '/../Fixtures/course.php';
+        $course = Course::create(getCourseData(), $semester);
+
+        yield [DataStorage::createWithInMemorySqliteDatabase(), $course];
+    }
+
+    /**
+     * @return Generator
+     * @throws StorageException
+     */
+    public function provideForTestPersistCourseDouble(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/current_semester.php';
+        $semester = Semester::create(getCurrentSemesterData());
+        $semesterDouble = Semester::create(getCurrentSemesterData());
+        include_once __DIR__ . '/../Fixtures/course.php';
+        $course = Course::create(getCourseData(), $semester);
+        $courseDouble = Course::create(getCourseData(), $semesterDouble);
+
+        yield [DataStorage::createWithInMemorySqliteDatabase(), $course, $courseDouble];
+    }
+
+    /**
+     * @return Generator
+     * @throws StorageException
+     */
+    public function provideForTestPersistPersonDouble(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/me.php';
+        $person = Person::create(getPersonMeData(), true);
+        $personDouble = Person::create(getPersonMeData(), true);
+
+        yield [DataStorage::createWithInMemorySqliteDatabase(), $person, $personDouble];
+    }
+
+    /**
+     * @return Generator
+     * @throws StorageException
+     */
+    public function provideForTestPersistSemesterDouble(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/me.php';
+        $semester = Semester::create(getCurrentSemesterData());
+        $semesterDouble = Semester::create(getCurrentSemesterData());
+
+        yield [DataStorage::createWithInMemorySqliteDatabase(), $semester, $semesterDouble];
+    }
+
+    /**
+     * @return Generator
+     * @throws StorageException
+     */
+    public function provideForTestPersistStudyDouble(): Generator
+    {
+        include_once __DIR__ . '/../Fixtures/study.php';
+        $study = Study::create(getStudyData());
+        $studyDouble = Study::create(getStudyData());
+
+        yield [DataStorage::createWithInMemorySqliteDatabase(), $study, $studyDouble];
+    }
+
+    /**
+     * @dataProvider provideForTestPersistCourse
+     *
+     * @param DataStorage $dataStorage
+     * @param Course $course
+     * @return void
+     * @throws ORMException
+     */
+    public function testPersistCourse(DataStorage $dataStorage, Course $course): void
+    {
+        $dataStorage->persistCourse($course);
+        $this->assertEquals($course, $dataStorage->getCourseRepository()->find($course->getId()));
+    }
+
+    /**
+     * @dataProvider provideForTestPersistCourseDouble
+     *
+     * @param DataStorage $dataStorage
+     * @param Course $course
+     * @param Course $courseDouble
+     * @return void
+     * @throws ORMException
+     */
+    public function testPersistCourseDouble(DataStorage $dataStorage, Course $course, Course $courseDouble): void
+    {
+        $dataStorage->persistSemester($course->getSemester());
+        $dataStorage->persistCourse($course);
+        $dataStorage->persistCourse($courseDouble);
+        $dataStorage->flush();
+
+        $this->assertCount(1, $dataStorage->getCourseRepository()->findAll());
+    }
+
+    /**
+     * @dataProvider provideForTestPersistPersonDouble
+     *
+     * @param DataStorage $dataStorage
+     * @param Person $person
+     * @param Person $personDouble
+     * @return void
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function testPersistPersonDouble(DataStorage $dataStorage, Person $person, Person $personDouble): void
+    {
+        $dataStorage->persistPerson($person);
+        $dataStorage->persistPerson($personDouble);
+        $dataStorage->flush();
+
+        $this->assertCount(1, $dataStorage->getPersonRepository()->findAll());
+    }
+
+    /**
+     * @dataProvider provideForTestPersistSemesterDouble
+     *
+     * @param DataStorage $dataStorage
+     * @param Semester $semester
+     * @param Semester $semesterDouble
+     * @return void
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function testPersistSemesterDouble(DataStorage $dataStorage, Semester $semester, Semester $semesterDouble): void
+    {
+        $dataStorage->persistSemester($semester);
+        $dataStorage->persistSemester($semesterDouble);
+        $dataStorage->flush();
+
+        $this->assertCount(1, $dataStorage->getSemesterRepository()->findAll());
+    }
+
+    /**
+     * @dataProvider provideForTestPersistStudyDouble
+     *
+     * @param DataStorage $dataStorage
+     * @param Study $study
+     * @param Study $studyDouble
+     * @return void
+     * @throws ORMException
+     * @throws OptimisticLockException
+     */
+    public function testPersistStudyDouble(DataStorage $dataStorage, Study $study, Study $studyDouble): void
+    {
+        $dataStorage->persistStudy($study);
+        $dataStorage->persistStudy($studyDouble);
+        $dataStorage->flush();
+
+        $this->assertCount(1, $dataStorage->getStudyRepository()->findAll());
+    }
+}


### PR DESCRIPTION
The client should be usable with a custom database connection, which means that it should be able to handle data updates.

The update mechanic was completely refactored to achieve this. At first updates were done by replacing old data objects (like course and semester) with the new ones. However, Doctrine uses object identity to check if an object is managed or not. This caused doctrine to persists every update as a new entity ... which causes a lot of problems.

Now, updates are applied to existing objects by passing them a data object of the same type. Primitive data are copied. Related objects are updated as well. The node tree is updated from root to leaf.

Tests were created to check the update mechanism.